### PR TITLE
Add -scene flag to load a specific .afoil at startup

### DIFF
--- a/game.go
+++ b/game.go
@@ -744,6 +744,23 @@ func (g *Game) runSliders() {
 	g.sliders.End()
 }
 
+// loadSceneFile loads path (e.g. the -scene startup flag) exactly as if it
+// had been chosen through the Open dialog, so Save afterward writes back to
+// the same file.
+func (g *Game) loadSceneFile(path string) error {
+	src, err := os.ReadFile(path) // #nosec G304 -- path comes from a command-line flag the user supplied
+	if err != nil {
+		return err
+	}
+	sc, err := sceneio.Load(string(src))
+	if err != nil {
+		return err
+	}
+	g.setScene(sc, path)
+	g.savePath = path
+	return nil
+}
+
 // openSceneDialog asks the OS for a scene file and loads it (paused at the
 // start). A cancel or a load error leaves the current state unchanged.
 func (g *Game) openSceneDialog() {

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 
 	"github.com/hajimehoshi/ebiten/v2"
@@ -14,11 +15,23 @@ import (
 const windowTitle = "kutta — 2D wind tunnel"
 
 func main() {
+	scenePath := flag.String("scene", "", "path to an .afoil scene file to load at startup instead of the interactive default foil")
+	flag.Parse()
+
 	ebiten.SetWindowSize(winW, winH)
 	ebiten.SetWindowTitle(windowTitle)
 	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeEnabled)
 	setWindowIcon()
-	err := ebiten.RunGame(NewGame())
+
+	g := NewGame()
+	if *scenePath != "" {
+		err := g.loadSceneFile(*scenePath)
+		if err != nil {
+			log.Printf("kutta: -scene %q: %v", *scenePath, err)
+		}
+	}
+
+	err := ebiten.RunGame(g)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION

(Following up from #7 — a bit more background on what im trying to do)
For the exhibit, I want it to boot directly into our airplane's profile with
no manual steps.

## Summary
`kutta -scene myplane.afoil` loads that scene at startup in place of the
interactive default foil, via the same load path the Open dialog already
uses — so Cmd+S afterward saves back to the same file.

## Why
Repeatedly re-opening the same file by hand every launch is friction for any
repeated-demo or kiosk-style setup (a booth, a class demo, a fixed display).

## How to use it
    kutta -scene path/to/scene.afoil

A bad/missing path logs a warning and falls back to the normal interactive
foil rather than failing to start.

## Test plan
- [x] `go build ./... && go vet ./... && golangci-lint run ./... && go test ./...`
- [ ] `kutta -scene examples/flap.afoil` opens directly into that scene.
- [ ] `kutta -scene /nonexistent.afoil` logs a warning and starts normally.
