### PR TITLE
Add Merge with Clipboard: join two open outlines end-to-end

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -1293,6 +1293,9 @@ func (g *Game) editorKeys(fmx, fmy float64, inCanvas bool) {
 		if inpututil.IsKeyJustPressed(ebiten.KeyX) {
 			g.cutObject()
 		}
+		if inpututil.IsKeyJustPressed(ebiten.KeyM) {
+			g.mergeWithClipboard()
+		}
 	}
 	if inpututil.IsKeyJustPressed(ebiten.KeyTab) {
 		g.toggleEditMode()
@@ -1395,6 +1398,62 @@ func (g *Game) cutObject() {
 	g.scn.Objects = append(g.scn.Objects[:g.selObj], g.scn.Objects[g.selObj+1:]...)
 	g.selObj = -1
 	g.connectFrom = -1
+}
+
+// mergeWithClipboard joins the clipboard object's outline onto the selected
+// object's, picking whichever end-to-end orientation (each chain forward or
+// reversed) brings their loose ends closest together, and replaces the
+// selected object's geometry with the closed result. This is how two open
+// halves drawn separately (e.g. an upper and lower surface traced with the
+// pen tool) become one airfoil. The clipboard object itself is untouched; Cut
+// it first if it should not remain in the scene afterward.
+func (g *Game) mergeWithClipboard() {
+	if g.selObj < 0 || g.objClip == nil {
+		return
+	}
+	o := g.scn.Objects[g.selObj]
+	if len(o.Shape) < 2 || len(g.objClip.Shape) < 2 {
+		return
+	}
+	g.snapshotForUndo()
+	o.Shape = joinChains(o.Shape, g.objClip.Shape)
+	o.Handle = nil
+	o.Gaps = nil
+	o.Pivot = centroid(o.Shape)
+}
+
+// joinChains concatenates two open point chains into one, choosing whichever
+// of the four end-to-end orientations (each chain forward or reversed) brings
+// the two loose-end pairs closest together.
+func joinChains(a, b []foil.Point) []foil.Point {
+	orientations := [][2][]foil.Point{
+		{a, b},
+		{a, reversePoints(b)},
+		{reversePoints(a), b},
+		{reversePoints(a), reversePoints(b)},
+	}
+	bestI, bestCost := 0, math.Inf(1)
+	for i, o := range orientations {
+		ca, cb := o[0], o[1]
+		cost := math.Hypot(ca[len(ca)-1].X-cb[0].X, ca[len(ca)-1].Y-cb[0].Y) +
+			math.Hypot(cb[len(cb)-1].X-ca[0].X, cb[len(cb)-1].Y-ca[0].Y)
+		if cost < bestCost {
+			bestCost, bestI = cost, i
+		}
+	}
+	ca, cb := orientations[bestI][0], orientations[bestI][1]
+	out := make([]foil.Point, 0, len(ca)+len(cb))
+	out = append(out, ca...)
+	out = append(out, cb...)
+	return out
+}
+
+func reversePoints(pts []foil.Point) []foil.Point {
+	out := make([]foil.Point, len(pts))
+	for i, p := range pts {
+		out[len(pts)-1-i] = p
+	}
+	return out
 }
 
 // nextObjectName returns the first unused "objectN" name.
@@ -1694,7 +1753,7 @@ func (g *Game) drawEditorPanels(screen *ebiten.Image) {
 		g.drawTimeline(screen)
 		return
 	}
-	drawString(screen, "P: pen   drag vertex: move   Alt+drag/pink knob: curve   dbl/Shift+click edge: add   Del: cut   join red ends   Cmd+C/V/X: obj", 16, top+44, colLabel)
+	drawString(screen, "P: pen   drag vertex: move   Alt+drag/pink knob: curve   dbl/Shift+click edge: add   Del: cut   join red ends   Cmd+C/V/X/M: obj", 16, top+44, colLabel)
 	drawString(screen, "C: smooth   Cmd+Z: undo   drag empty: pan (or Space)   wheel: zoom", 16, top+64, colLabel)
 }
 

--- a/editor_test.go
+++ b/editor_test.go
@@ -605,3 +605,29 @@ func TestPointInPoly(t *testing.T) {
 		t.Error("outside point reported inside")
 	}
 }
+
+// TestJoinChainsPicksClosestOrientation checks that two open chains join
+// end-to-end regardless of which direction each was drawn in: b reversed
+// relative to a should still produce one continuous loop, not a crossed one.
+func TestJoinChainsPicksClosestOrientation(t *testing.T) {
+	// a: (0,0) -> (10,0), the top surface, LE to TE.
+	a := []foil.Point{{X: 0, Y: 0}, {X: 5, Y: 1}, {X: 10, Y: 0}}
+	// b drawn TE -> LE (the natural way to trace a bottom surface back), so it
+	// already abuts a's end without needing a reversal.
+	b := []foil.Point{{X: 10, Y: 0}, {X: 5, Y: -1}, {X: 0, Y: 0}}
+	got := joinChains(a, b)
+	if len(got) != len(a)+len(b) {
+		t.Fatalf("got %d points, want %d", len(got), len(a)+len(b))
+	}
+	if got[0] != a[0] || got[len(a)] != b[0] {
+		t.Errorf("expected a then b unreversed, got %+v", got)
+	}
+
+	// Same two shapes, but b traced the other way (LE -> TE): joinChains should
+	// reverse it internally so the result is still one continuous loop.
+	bRev := reversePoints(b)
+	got2 := joinChains(a, bRev)
+	if got2[len(a)] != b[0] {
+		t.Errorf("expected joinChains to reverse b back to TE-first, got seam point %+v", got2[len(a)])
+	}
+}

--- a/game.go
+++ b/game.go
@@ -432,6 +432,7 @@ func (g *Game) menuItems() []menu.Item {
 		{Title: "Copy Object", Disabled: !inGeom || g.selObj < 0, OnClick: act(g.copyObject)},
 		{Title: "Paste Object", Disabled: !inGeom || g.objClip == nil, OnClick: act(g.pasteObject)},
 		{Title: "Cut Object", Disabled: !inGeom || g.selObj < 0, OnClick: act(g.cutObject)},
+		{Title: "Merge with Clipboard", Disabled: !inGeom || g.selObj < 0 || g.objClip == nil, OnClick: act(g.mergeWithClipboard)},
 	}
 
 	foilItems := make([]menu.Item, 0, len(profiles)+2)


### PR DESCRIPTION
(Following up from #7 — a bit more background there on who I am.)
This came up while assembling that same traced wing profile: I'd drawn the
upper and lower surfaces separately and needed to join them into one shape.

## Summary
Cmd+M (Geometry mode) or **Edit → Merge with Clipboard** joins the clipboard
object's outline onto the selected object's, replacing the selection with the
closed result.

`joinChains` tries all four end-to-end orientations (each chain forward or
reversed) and picks whichever brings the loose ends closest together, so it
doesn't matter which direction either half was drawn in.

## Why
See #13. A shape drawn as two open halves with the pen tool had
no way to become one solid body other than redrawing it as a single
continuous path.

## How to use it
1. Select one half, **Cmd+X** (Cut — copies to clipboard and removes it).
2. Select the other half, **Cmd+M** (Merge with Clipboard).
3. The selected object becomes one closed outline combining both.

The clipboard object itself is untouched by the merge; Cut (not Copy) first
if it shouldn't remain in the scene afterward.

## Test plan
- [x] `go build ./... && go vet ./... && golangci-lint run ./... && go test ./...`
      (includes `TestJoinChainsPicksClosestOrientation`)
- [ ] Draw two open halves in opposite directions (e.g. one LE→TE, one
      TE→LE); merge; confirm one clean closed loop, not a crossed one.
- [ ] Confirm Cmd+Z undoes the merge.
