### PR TITLE
narrow solver populations to float32

### DIFF
--- a/lbm/lbm.go
+++ b/lbm/lbm.go
@@ -52,7 +52,11 @@ type Solver struct {
 	omega float64 // BGK relaxation rate, 1/tau
 	u0    float64 // free-stream speed in lattice units, along +x
 
-	f, ftmp [9][]float64 // distribution functions, double-buffered for streaming
+	// Populations are float32 to halve the solver's memory footprint and traffic;
+	// the kernel is memory-bound, so this is the lever, not more arithmetic. All
+	// math is still done in float64 (promote on read, demote on write), so only
+	// storage precision drops. Macroscopic fields stay float64 for the API.
+	f, ftmp [9][]float32 // distribution functions, double-buffered for streaming
 	solid   []bool       // true where a cell is part of the body (wall)
 
 	// Macroscopic fields, refreshed every Step and indexed y*NX+x. Exposed for
@@ -106,8 +110,8 @@ func New(nx, ny int, tau, u0 float64) *Solver {
 		Uy:    make([]float64, nx*ny),
 	}
 	for i := range 9 {
-		s.f[i] = make([]float64, nx*ny)
-		s.ftmp[i] = make([]float64, nx*ny)
+		s.f[i] = make([]float32, nx*ny)
+		s.ftmp[i] = make([]float32, nx*ny)
 	}
 	s.Reset()
 	return s
@@ -121,7 +125,7 @@ func (s *Solver) Reset() {
 		s.Ux[c] = s.u0
 		s.Uy[c] = 0
 		for i := range 9 {
-			s.f[i][c] = feq(i, 1, s.u0, 0)
+			s.f[i][c] = float32(feq(i, 1, s.u0, 0))
 		}
 	}
 }
@@ -144,7 +148,7 @@ func (s *Solver) UpdateSolid(mask []bool) {
 	for c := range mask {
 		if s.solid[c] && !mask[c] {
 			for i := range 9 {
-				s.f[i][c] = feq(i, 1, s.u0, 0)
+				s.f[i][c] = float32(feq(i, 1, s.u0, 0))
 			}
 		}
 		s.solid[c] = mask[c]
@@ -219,7 +223,7 @@ func (s *Solver) collideRange(c0, c1 int) {
 		mx := 0.0
 		my := 0.0
 		for i := range 9 {
-			fi := s.f[i][c]
+			fi := float64(s.f[i][c])
 			rho += fi
 			mx += fi * exf[i]
 			my += fi * eyf[i]
@@ -253,7 +257,8 @@ func (s *Solver) collideRange(c0, c1 int) {
 		wrho := rho * s.omega
 		for i := range 9 {
 			cu := exf[i]*ux + eyf[i]*uy
-			s.f[i][c] += wrho*w[i]*(base+3*cu+4.5*cu*cu) - s.omega*s.f[i][c]
+			fi := float64(s.f[i][c])
+			s.f[i][c] = float32(fi + wrho*w[i]*(base+3*cu+4.5*cu*cu) - s.omega*fi)
 		}
 	}
 }
@@ -265,9 +270,9 @@ func (s *Solver) applyBoundaries() {
 	nx, ny := s.NX, s.NY
 	// Every free-stream boundary cell gets the same nine equilibrium values,
 	// so they are computed once per call instead of once per cell.
-	var eq [9]float64
+	var eq [9]float32
 	for i := range 9 {
-		eq[i] = feq(i, 1, s.u0, 0)
+		eq[i] = float32(feq(i, 1, s.u0, 0))
 	}
 	for y := range ny {
 		c := y * nx

--- a/lbm/precision_test.go
+++ b/lbm/precision_test.go
@@ -1,0 +1,54 @@
+package lbm
+
+import (
+	"math"
+	"testing"
+)
+
+// Reference forces after 500 steps, captured from the float64-population
+// solver before the populations were narrowed to float32. Storing populations
+// at single precision moves these values in the sixth significant digit, which
+// is the float32 noise floor and far below anything the readouts or the color
+// maps can show. The guard exists so a future change to the kernel or to the
+// storage precision has to face the numbers rather than pass unnoticed.
+var precisionRef = []struct {
+	name        string
+	broadside   bool
+	fx, mz, sep float64
+}{
+	{"thin", false, 0.0770296427, -7.6644494466, 0.025806451612903226},
+	{"broadside", true, 4.4725827712, -445.0219857300, 0.9419354838709677},
+}
+
+// relTol is generous next to the measured drift (about 2e-6) and still tight
+// enough to catch a real regression.
+const relTol = 1e-4
+
+func TestPrecisionStaysWithinTolerance(t *testing.T) {
+	for _, tc := range precisionRef {
+		t.Run(tc.name, func(t *testing.T) {
+			s := benchSolver(tc.broadside)
+			for range 500 {
+				s.Step()
+			}
+			if !s.Finite() {
+				t.Fatal("solver went non-finite over 500 steps")
+			}
+			checkRel(t, "Fx", s.Fx, tc.fx)
+			checkRel(t, "Mz", s.Mz, tc.mz)
+			// Sep is a ratio of face counts, so it is exact regardless of the
+			// population precision.
+			if s.Sep != tc.sep {
+				t.Errorf("Sep = %v, want exactly %v", s.Sep, tc.sep)
+			}
+		})
+	}
+}
+
+func checkRel(t *testing.T, name string, got, want float64) {
+	t.Helper()
+	rel := math.Abs(got-want) / math.Abs(want)
+	if rel > relTol {
+		t.Errorf("%s = %.10f, want %.10f (relative error %.2e exceeds %.0e)", name, got, want, rel, relTol)
+	}
+}

--- a/lbm/stream_equiv_test.go
+++ b/lbm/stream_equiv_test.go
@@ -61,10 +61,10 @@ func TestStreamMatchesReference(t *testing.T) {
 		s.applyBoundaries()
 		s.computeForce()
 
-		ref := make([][]float64, 9)
+		ref := make([][]float32, 9)
 		s.streamReference()
 		for i := range 9 {
-			ref[i] = append([]float64(nil), s.ftmp[i]...)
+			ref[i] = append([]float32(nil), s.ftmp[i]...)
 		}
 		s.stream()
 		for i := range 9 {


### PR DESCRIPTION
The kernel is memory-bound, so halving the population arrays is worth more than any arithmetic change. All math stays in float64; only storage narrows, which drops the solver footprint from 11.5 to 6.6 MB.

Measured on a Pi 4 (four Cortex-A72), where the parallel path saturates the memory bus: one core gains 6%, but four cores gain 29% (12.80 -> 9.09 ms per step), and scaling improves from 1.94x to 2.65x. The win tracks memory pressure, which is why it barely shows on one core and shows up fully once every core is competing for the bus. macOS gains a little too (frame 2.4%, serial 3.4%), so nothing regresses there.

Physics drift is at the float32 noise floor, about 2e-6 relative on the forces, and Sep is exact since it is a ratio of face counts. precision_test pins that against the float64 reference values.