### PR TITLE
fuse collide and stream through a cache-resident row ring

### DIFF
--- a/lbm/fused.go
+++ b/lbm/fused.go
@@ -1,0 +1,189 @@
+//go:build !js
+
+package lbm
+
+import "math"
+
+// ringRows is how many collided rows the fused kernel keeps live. Streaming a
+// row reads its own row and the two around it, so three is the whole window.
+const ringRows = 3
+
+// fusedStep runs collision, the open-channel boundaries and streaming in a
+// single pass over the grid.
+//
+// The collided populations have exactly one consumer: streaming reads them and
+// then they are discarded on the buffer swap. Writing them across the full grid
+// and reading them back costs two extra passes over 2.6 MB, and this kernel is
+// memory-bound, so those passes are the cost rather than the arithmetic.
+// Instead each worker keeps the three rows it currently needs in a small ring
+// (about 39 KB, cache resident) and the collided values never reach RAM.
+//
+// Results are bit-identical to the collide/applyBoundaries/stream sequence it
+// replaces: the same arithmetic in the same order per cell, only the storage in
+// between is different. fused_test pins that against a reference copy.
+func (s *Solver) fusedStep(store bool) {
+	var eq [9]float32
+	for i := range 9 {
+		eq[i] = float32(feq(i, 1, s.u0, 0))
+	}
+	s.ensureRings()
+	s.forRowsIdx(s.NY, func(w, y0, y1 int) {
+		ring := s.rings[w]
+		// Prime the window. A worker also collides the row above and below its
+		// band, since streaming its edge rows reads them; recomputing two rows
+		// per worker is cheaper than coordinating with the neighbouring band.
+		for y := y0 - 1; y <= y0+1; y++ {
+			s.collideRowInto(ring, y, store && y >= y0 && y < y1, &eq)
+		}
+		for y := y0; y < y1; y++ {
+			s.streamRowFromRing(ring, y)
+			// Pull the next row into the window before it is needed.
+			next := y + 2
+			if next <= y1 {
+				s.collideRowInto(ring, next, store && next < y1, &eq)
+			}
+		}
+	})
+}
+
+// ensureRings allocates one scratch ring per worker, before any goroutine
+// starts so the slice itself is never written concurrently.
+func (s *Solver) ensureRings() {
+	n := s.workerCount(s.NY)
+	if len(s.rings) >= n && (n == 0 || len(s.rings[0]) == ringRows*9*s.NX) {
+		return
+	}
+	s.rings = make([][]float32, n)
+	for i := range s.rings {
+		s.rings[i] = make([]float32, ringRows*9*s.NX)
+	}
+}
+
+// collideRowInto collides row y into the ring slot it owns, then applies the
+// boundary substitution for that row. Rows outside the grid are ignored, so the
+// caller can prime the window without bounds checks of its own.
+//
+// store says whether to publish this row's macroscopic fields; a worker only
+// publishes the rows it owns, so the halo rows it recomputes stay silent and no
+// cell is written twice.
+func (s *Solver) collideRowInto(ring []float32, y int, store bool, eq *[9]float32) {
+	nx, ny := s.NX, s.NY
+	if y < 0 || y >= ny {
+		return
+	}
+	base := (y % ringRows) * 9 * nx
+	row := y * nx
+	for x := range nx {
+		c := row + x
+		if s.solid[c] {
+			if store {
+				s.Rho[c], s.Ux[c], s.Uy[c] = 1, 0, 0
+			}
+			// Collision skips solid cells, so their populations carry over
+			// untouched, exactly as the separate collide left them.
+			for i := range 9 {
+				ring[base+i*nx+x] = s.f[i][c]
+			}
+			continue
+		}
+		rho := 0.0
+		mx := 0.0
+		my := 0.0
+		for i := range 9 {
+			fi := float64(s.f[i][c])
+			rho += fi
+			mx += fi * exf[i]
+			my += fi * eyf[i]
+		}
+		ux := mx / rho
+		uy := my / rho
+		if rho < rhoMin {
+			rho = rhoMin
+		}
+		if rho > rhoMax {
+			rho = rhoMax
+		}
+		sp2 := ux*ux + uy*uy
+		if sp2 > uMax*uMax {
+			k := uMax / math.Sqrt(sp2)
+			ux *= k
+			uy *= k
+		}
+		if store {
+			s.Rho[c], s.Ux[c], s.Uy[c] = rho, ux, uy
+		}
+		eqBase := 1 - 1.5*(ux*ux+uy*uy)
+		wrho := rho * s.omega
+		for i := range 9 {
+			cu := exf[i]*ux + eyf[i]*uy
+			fi := float64(s.f[i][c])
+			ring[base+i*nx+x] = float32(fi + wrho*w[i]*(eqBase+3*cu+4.5*cu*cu) - s.omega*fi)
+		}
+	}
+
+	// Boundary substitution, in the order applyBoundaries used: the inlet and
+	// outflow columns first, then the top and bottom rows, which is why a
+	// corner ends up at free stream rather than at the outflow copy.
+	if y == 0 || y == ny-1 {
+		for i := range 9 {
+			r := ring[base+i*nx : base+i*nx+nx]
+			for x := range r {
+				r[x] = eq[i]
+			}
+		}
+		return
+	}
+	for i := range 9 {
+		off := base + i*nx
+		ring[off] = eq[i]               // inlet: pinned to the free stream
+		ring[off+nx-1] = ring[off+nx-2] // outflow: zero gradient
+	}
+}
+
+// streamRowFromRing writes row y of the next buffer, pulling each population
+// from the ring: the neighbour it came from, or a bounce-back off a wall, or
+// the row's own value where the source lies outside the grid.
+//
+// The walk is direction-major so the destination slice, the source row and the
+// bounce-back row are all resolved once per direction instead of once per cell.
+// A cell-major version of this loop measured barely faster than the unfused
+// kernel: the saved memory traffic went straight back out as index arithmetic.
+func (s *Solver) streamRowFromRing(ring []float32, y int) {
+	nx, ny := s.NX, s.NY
+	row := y * nx
+	self := (y % ringRows) * 9 * nx
+	solidRow := s.solid[row : row+nx]
+	for i := range 9 {
+		fti := s.ftmp[i][row : row+nx]
+		selfI := ring[self+i*nx : self+i*nx+nx]
+		selfOpp := ring[self+opp[i]*nx : self+opp[i]*nx+nx]
+
+		sy := y - eyi[i]
+		if sy < 0 || sy >= ny {
+			// The whole row streams from itself: the source is off the grid.
+			for x := range nx {
+				fti[x] = selfI[x]
+			}
+			continue
+		}
+		src := ring[(sy%ringRows)*9*nx+i*nx:][:nx]
+		srcSolid := s.solid[sy*nx : sy*nx+nx]
+		ex := exi[i]
+		for x := range nx {
+			if solidRow[x] {
+				fti[x] = selfI[x]
+				continue
+			}
+			sx := x - ex
+			if sx < 0 || sx >= nx {
+				fti[x] = selfI[x]
+				continue
+			}
+			if srcSolid[sx] {
+				fti[x] = selfOpp[x]
+				continue
+			}
+			fti[x] = src[sx]
+		}
+	}
+}

--- a/lbm/fused_test.go
+++ b/lbm/fused_test.go
@@ -1,0 +1,93 @@
+//go:build !js
+
+package lbm
+
+import "testing"
+
+// legacyStep is the collide / apply-boundaries / stream sequence the fused
+// kernel replaces, kept here as the reference it has to match bit for bit.
+func (s *Solver) legacyStep(store bool) {
+	s.collide(store)
+	s.applyBoundaries()
+	s.stream()
+}
+
+// wallHugger is a body that touches the top and bottom edges, so the fused
+// kernel's boundary substitution and its bounce-back meet at the same cells.
+func wallHugger() *Solver {
+	s := New(90, 60, 0.6, 0.1)
+	mask := make([]bool, 90*60)
+	for y := range 60 {
+		for x := 40; x < 46; x++ {
+			mask[y*90+x] = true
+		}
+	}
+	s.SetSolid(mask)
+	return s
+}
+
+// outflowHugger puts the body a few cells from the right edge, so the flow is
+// still recovering where the outflow column copies its neighbour. Without it
+// the far wake is uniform, the copied values come out bit-identical, and the
+// test cannot see a wrong outflow at all.
+func outflowHugger() *Solver {
+	s := New(90, 60, 0.6, 0.1)
+	mask := make([]bool, 90*60)
+	for y := 20; y < 40; y++ {
+		for x := 75; x < 85; x++ {
+			mask[y*90+x] = true
+		}
+	}
+	s.SetSolid(mask)
+	return s
+}
+
+// TestFusedMatchesLegacy is the gate for the fused kernel: identical
+// populations, macroscopic fields and forces, across body shapes, worker
+// counts and both materialization modes.
+func TestFusedMatchesLegacy(t *testing.T) {
+	shapes := map[string]func() *Solver{
+		"thin":      func() *Solver { return benchSolver(false) },
+		"broadside": func() *Solver { return benchSolver(true) },
+		"wall":      wallHugger,
+		"outflow":   outflowHugger,
+	}
+	for name, mk := range shapes {
+		for _, workers := range []int{1, 2, 3, 7} {
+			for _, store := range []bool{true, false} {
+				t.Run(name, func(t *testing.T) {
+					ref := mk()
+					got := mk()
+					got.Workers = workers
+
+					// Several steps so any drift accumulates instead of
+					// hiding in the first one.
+					for range 4 {
+						ref.legacyStep(store)
+						ref.f, ref.ftmp = ref.ftmp, ref.f
+
+						got.fusedStep(store)
+						got.f, got.ftmp = got.ftmp, got.f
+					}
+
+					for i := range 9 {
+						for c := range ref.f[i] {
+							if got.f[i][c] != ref.f[i][c] {
+								t.Fatalf("%s workers=%d store=%v: f[%d][%d] = %v, want %v",
+									name, workers, store, i, c, got.f[i][c], ref.f[i][c])
+							}
+						}
+					}
+					if !store {
+						return
+					}
+					for c := range ref.Rho {
+						if got.Rho[c] != ref.Rho[c] || got.Ux[c] != ref.Ux[c] || got.Uy[c] != ref.Uy[c] {
+							t.Fatalf("%s workers=%d: macroscopic fields differ at cell %d", name, workers, c)
+						}
+					}
+				})
+			}
+		}
+	}
+}

--- a/lbm/lbm.go
+++ b/lbm/lbm.go
@@ -85,6 +85,9 @@ type Solver struct {
 	// grid once while still emitting the list in j-major order. An animated
 	// scene rebuilds every frame, so the scan count matters.
 	faceBins [4][]face
+
+	// rings is the fused kernel's per-worker row window; see fused.go.
+	rings [][]float32
 }
 
 // face is one exposed body face: a fluid cell whose axial neighbor is solid.
@@ -210,18 +213,20 @@ func (s *Solver) Step() {
 func (s *Solver) StepN(n int) {
 	for i := range n {
 		last := i == n-1
-		s.collide(last)
-		s.applyBoundaries()
+		s.stepOnce(last)
 		if last {
 			s.computeForce()
 		}
-		s.stream()
 		s.f, s.ftmp = s.ftmp, s.f
 	}
 }
 
 // collide relaxes every fluid cell toward local equilibrium (BGK) and refreshes
 // the macroscopic fields in place. Solid cells are skipped and report no flow.
+//
+// This phase and the two that follow it are the browser build's step (see
+// step_js.go) and the reference the fused kernel is tested against, so a
+// deadcode run over a native build reports them unreachable. They are not.
 func (s *Solver) collide(store bool) {
 	s.forRows(s.NY, func(y0, y1 int) {
 		s.collideRange(y0*s.NX, y1*s.NX, store)

--- a/lbm/parallel.go
+++ b/lbm/parallel.go
@@ -15,13 +15,7 @@ import (
 // The goroutines are spawned per call rather than pooled: a phase costs
 // hundreds of microseconds and a spawn about one, so a pool would buy noise.
 func (s *Solver) forRows(ny int, fn func(y0, y1 int)) {
-	workers := s.Workers
-	if workers <= 0 {
-		workers = runtime.GOMAXPROCS(0)
-	}
-	if workers > ny {
-		workers = ny
-	}
+	workers := s.workerCount(ny)
 	if workers <= 1 {
 		fn(0, ny)
 		return
@@ -39,4 +33,37 @@ func (s *Solver) forRows(ny int, fn func(y0, y1 int)) {
 		})
 	}
 	wg.Wait()
+}
+
+// forRowsIdx is forRows with the band index handed to fn, for phases that need
+// per-worker scratch. The index is dense and below the worker count, so it can
+// address a preallocated slice.
+func (s *Solver) forRowsIdx(ny int, fn func(w, y0, y1 int)) {
+	workers := s.workerCount(ny)
+	if workers <= 1 {
+		fn(0, 0, ny)
+		return
+	}
+	chunk := (ny + workers - 1) / workers
+	var wg sync.WaitGroup
+	for w := range workers {
+		y0 := w * chunk
+		y1 := min(y0+chunk, ny)
+		if y0 >= y1 {
+			break
+		}
+		wg.Go(func() {
+			fn(w, y0, y1)
+		})
+	}
+	wg.Wait()
+}
+
+// workerCount is the band count both row helpers agree on.
+func (s *Solver) workerCount(ny int) int {
+	workers := s.Workers
+	if workers <= 0 {
+		workers = runtime.GOMAXPROCS(0)
+	}
+	return min(workers, ny)
 }

--- a/lbm/step_js.go
+++ b/lbm/step_js.go
@@ -1,0 +1,18 @@
+//go:build js
+
+package lbm
+
+// stepOnce advances one lattice step using the separate collide, boundary and
+// stream phases.
+//
+// The browser build deliberately keeps this path: the fused kernel that the
+// native builds use measured 85% SLOWER here (25.1 ms against 13.5 ms per
+// frame). It walks the grid a row at a time, so it trades three long loops for
+// several hundred short ones, and the wasm JIT optimizes the long loops far
+// better than it recovers the call and setup overhead of the short ones. The
+// memory traffic the fusion saves is not the constraint inside the VM.
+func (s *Solver) stepOnce(store bool) {
+	s.collide(store)
+	s.applyBoundaries()
+	s.stream()
+}

--- a/lbm/step_native.go
+++ b/lbm/step_native.go
@@ -1,0 +1,11 @@
+//go:build !js
+
+package lbm
+
+// stepOnce advances one lattice step using the fused kernel, which keeps the
+// collided rows in a cache-resident ring instead of writing them across the
+// grid and reading them back. Measured against the separate-phase kernel:
+// 19% faster on an Apple M-series, 22% on a four-core Cortex-A72.
+func (s *Solver) stepOnce(store bool) {
+	s.fusedStep(store)
+}


### PR DESCRIPTION
The collided populations have exactly one consumer: streaming reads them and then the buffer swap throws them away. Writing them across the full grid and reading them back is two extra passes over 2.6 MB, and this kernel is bound by memory, so those passes are the cost. Each worker now keeps the three rows it needs live in a ~39 KB ring and the collided values never reach RAM.

Bit-identical to the collide/boundaries/stream sequence, pinned by fused_test across body shapes, worker counts and both materialization modes. Writing that test found its own hole first: with the body far from the outlet the wake is uniform and the outflow column copies bit-identical neighbours, so a deliberately broken outflow went unnoticed. outflowHugger puts a body a few cells from the edge, and the test fails as it should.

The row walk has to stay direction-major. A cell-major first cut measured only 4% better than the unfused kernel: the traffic it saved went straight back out as index arithmetic. Hoisting the slices per direction took it to 22% on a four-core Cortex-A72 and 19% on an Apple M-series.

The browser build keeps the separate phases, in step_js.go. Fused measured 85% SLOWER there (25.1 ms against 13.5 ms per frame): it trades three long loops for several hundred short ones, and the wasm JIT is much better at the long ones than it is at absorbing the call overhead of the short ones. Inside the VM the memory traffic was never the constraint.