### PR TITLE
Add a particles toggle to show streamlines alone against a clean background

### DIFF
--- a/game.go
+++ b/game.go
@@ -169,16 +169,17 @@ type Game struct {
 
 	ptr pointer // this frame's pointer, mouse or finger; see pointer.go
 
-	profileIdx  int     // index into profiles for Tab-cycling presets
-	nacaCode    string  // active NACA 4-digit code (any code, not just a preset)
-	nacaInput   string  // NACA code being typed in the toolbar field
-	alphaDeg    float64 // angle of attack in degrees
-	u0          float64
-	controlDeg  float64 // live deflection of the scene's Control object, in degrees
-	mode        fieldMode
-	paused      bool
-	streamlines bool // overlay integrated streamlines
-	glow        bool // additive bloom on the smoke
+	profileIdx    int     // index into profiles for Tab-cycling presets
+	nacaCode      string  // active NACA 4-digit code (any code, not just a preset)
+	nacaInput     string  // NACA code being typed in the toolbar field
+	alphaDeg      float64 // angle of attack in degrees
+	u0            float64
+	controlDeg    float64 // live deflection of the scene's Control object, in degrees
+	mode          fieldMode
+	paused        bool
+	streamlines   bool // overlay integrated streamlines
+	glow          bool // additive bloom on the smoke
+	showParticles bool // draw the smoke tracers at all; off isolates streamlines with a clean background
 	// clean hides every panel/control, drawing only the flow image -- exactly
 	// what -hidecontrols has always meant, on its own. kiosk adds the rest of
 	// kiosk mode on top of that: a trimmed menu bar and blocking
@@ -324,11 +325,12 @@ type Game struct {
 // NewGame builds the simulation, geometry and render targets.
 func NewGame() *Game {
 	g := &Game{
-		alphaDeg:  4,
-		u0:        defaultU,
-		glow:      true,
-		nacaCode:  profiles[0],
-		nacaInput: profiles[0],
+		alphaDeg:      4,
+		u0:            defaultU,
+		glow:          true,
+		showParticles: true,
+		nacaCode:      profiles[0],
+		nacaInput:     profiles[0],
 	}
 	g.sim = lbm.New(gridW, gridH, tau, g.u0)
 	g.smoke = viz.NewParticles(nParticles, gridW, gridH, 1)
@@ -626,6 +628,7 @@ func (g *Game) menuItems() []menu.Item {
 			{Separator: true},
 			{Title: mark(g.streamlines) + "Streamlines", OnClick: act(func() { g.streamlines = !g.streamlines })},
 			{Title: mark(g.glow) + "Glow", OnClick: act(func() { g.glow = !g.glow })},
+			{Title: mark(g.showParticles) + "Particles", OnClick: act(func() { g.showParticles = !g.showParticles })},
 			{Title: mark(g.paused) + "Pause", OnClick: act(func() { g.paused = !g.paused })},
 			{Separator: true},
 			{Title: "Enter Kiosk Mode", OnClick: act(func() { g.enterKiosk(false) })},
@@ -647,6 +650,7 @@ type menuSig struct {
 	mode          fieldMode
 	streamlines   bool
 	glow          bool
+	showParticles bool
 	paused        bool
 	snapOn        bool
 	nacaCode      string
@@ -667,6 +671,7 @@ func (g *Game) menuSignature() menuSig {
 		mode:          g.mode,
 		streamlines:   g.streamlines,
 		glow:          g.glow,
+		showParticles: g.showParticles,
 		paused:        g.paused,
 		snapOn:        g.snapOn,
 		nacaCode:      g.nacaCode,
@@ -947,6 +952,9 @@ func (g *Game) handleInput() {
 	if inpututil.IsKeyJustPressed(ebiten.KeyG) {
 		g.glow = !g.glow
 	}
+	if inpututil.IsKeyJustPressed(ebiten.KeyP) {
+		g.showParticles = !g.showParticles
+	}
 	if inpututil.IsKeyJustPressed(ebiten.KeySpace) {
 		g.paused = !g.paused
 	}
@@ -1205,7 +1213,9 @@ func (g *Game) Draw(screen *ebiten.Image) {
 	op.Filter = ebiten.FilterLinear
 	vp.DrawImage(g.fieldImg, op)
 
-	g.drawSmoke(vp)
+	if g.showParticles {
+		g.drawSmoke(vp)
+	}
 	if g.streamlines {
 		g.drawStreamlines(vp)
 	}
@@ -1737,6 +1747,7 @@ func (g *Game) drawBottomPanel(screen *ebiten.Image) {
 		{"V", "speed/vort/press"},
 		{"S", "streamlines"},
 		{"G", "glow / bloom"},
+		{"P", "particles"},
 		{"[  ]", "inlet speed"},
 		{"Space", "pause / resume"},
 		{"N", "step (paused)"},

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	kiosk := flag.Bool("kiosk", false, "start fullscreen in kiosk mode (no menu, no panels)")
 	kioskControls := flag.Bool("kiosk-controls", false, "in kiosk mode, keep the AoA/speed/control sliders visible and usable")
 	glow := flag.Bool("glow", true, "additive bloom on the smoke")
+	particles := flag.Bool("particles", true, "draw the smoke tracers; turn off to show streamlines alone against a clean background")
 	streamlines := flag.Bool("streamlines", false, "overlay integrated streamlines")
 	mode := flag.String("mode", "", "field display at startup: speed, vorticity, or pressure (default speed)")
 	udpAddr := flag.String("udp", "", "listen address (e.g. :9000) for UDP slider control from external hardware; disabled if empty")
@@ -35,6 +36,7 @@ func main() {
 	g := NewGame()
 	g.perf.enabled = *debug
 	g.glow = *glow
+	g.showParticles = *particles
 	g.streamlines = *streamlines
 	if *mode != "" {
 		fm, ok := parseFieldMode(*mode)

--- a/udpcontrol.go
+++ b/udpcontrol.go
@@ -22,10 +22,10 @@ import (
 // this kind of private/local use), chosen automatically by whether the host
 // parses as a multicast IP.
 //
-// Channels: AOA and SPD (angle of attack, inlet speed, both numeric), GLOW
-// and STREAMLINES (0 or 1), and MODE (speed, vorticity, or pressure). A
-// control-surface channel is a natural follow-up once there's a live
-// control-surface slider for it to drive.
+// Channels: AOA and SPD (angle of attack, inlet speed, both numeric), GLOW,
+// STREAMLINES and PARTICLES (0 or 1), and MODE (speed, vorticity, or
+// pressure). A control-surface channel is a natural follow-up once there's a
+// live control-surface slider for it to drive.
 func (g *Game) startUDPControl(addr string) error {
 	conn, err := listenUDPControl(addr)
 	if err != nil {
@@ -121,6 +121,13 @@ func (g *Game) applyControlMessage(line string) {
 			return
 		}
 		g.enqueue(func() { g.streamlines = on != 0 })
+	case "PARTICLES":
+		on, perr := strconv.ParseFloat(value, 64)
+		if perr != nil {
+			log.Printf("kutta: UDP control: PARTICLES wants 0 or 1, got %q", value)
+			return
+		}
+		g.enqueue(func() { g.showParticles = on != 0 })
 	case "MODE":
 		fm, fok := parseFieldMode(value)
 		if !fok {

--- a/udpcontrol_test.go
+++ b/udpcontrol_test.go
@@ -77,6 +77,18 @@ func TestApplyControlMessageTogglesAndMode(t *testing.T) {
 		t.Error("STREAMLINES 1 should turn streamlines on")
 	}
 
+	g.applyControlMessage("PARTICLES 0")
+	g.drainPending()
+	if g.showParticles {
+		t.Error("PARTICLES 0 should turn particles off")
+	}
+
+	g.applyControlMessage("PARTICLES 1")
+	g.drainPending()
+	if !g.showParticles {
+		t.Error("PARTICLES 1 should turn particles on")
+	}
+
 	g.applyControlMessage("MODE pressure")
 	g.drainPending()
 	if g.mode != modePressure {


### PR DESCRIPTION
Closes #26.

Adds a fourth independent display toggle alongside Glow/Streamlines/Mode: `showParticles`, controlling whether the smoke tracers draw at all.

- **Menu**: View → Particles (checkbox, next to Glow)
- **Keyboard**: `P`
- **CLI**: `-particles` (default `true`)
- **UDP**: `PARTICLES 0`/`PARTICLES 1`, mirrors the existing `GLOW`/`STREAMLINES` channels exactly

Kept as an independent bool rather than merged into Glow's on/off state: Glow is bloom applied to the smoke layer, so it's naturally inert with particles hidden, but that's the same relationship grid-snap has to a hidden grid — not a reason to fuse two controls into one exclusive state. With separate toggles, hiding and re-showing particles doesn't clobber whatever Glow setting was already chosen.

When particles are hidden, the smoke draw is skipped entirely (not just hidden visually) — fade/stamp/vertex-build work and the bloom pass are all bypassed, so this is free CPU/GPU-wise, not just a display change.

Tested: `go test ./...` passes; manually verified all four entry points (menu, key, flag, UDP) toggle the same state and streamlines render correctly with particles off.