### PR TITLE
add -tps: trade wasted ticks for drawn frames on slow machines

### DIFF
--- a/game.go
+++ b/game.go
@@ -149,6 +149,8 @@ type Game struct {
 
 	perf perfLog // -debug terminal metrics; see perflog.go
 
+	tps int // tick rate; 0 means the standard 60 (see tickrate.go)
+
 	// Scratch storage for the per-frame body rebuild (mask rasterization and
 	// scene polygon transforms). Reused serially within a frame, never held
 	// across one; keeps an animated scene at zero allocations after warm-up.
@@ -746,12 +748,12 @@ func (g *Game) Update() error {
 	// Advance the timeline only while playing; the fluid keeps simulating either
 	// way, so a frozen pose still develops its steady flow.
 	if g.scn != nil && g.animPlaying {
-		g.animTime += animDt
+		g.animTime += animDt * g.tickScale()
 		g.sim.UpdateSolid(g.sceneMask(g.scn.LoopTime(g.animTime)))
 	}
-	g.stepSim(substeps)
-	g.smoke.Step(g.sim, tracerSpeed)
-	const a = 0.04 // EMA smoothing for the displayed forces
+	g.stepSim(g.substepsPerTick())
+	g.smoke.Step(g.sim, tracerSpeed*g.tickScale())
+	a := g.emaAlphaPerTick() // EMA smoothing for the displayed forces
 	g.fxEMA += a * (g.sim.Fx - g.fxEMA)
 	g.fyEMA += a * (g.sim.Fy - g.fyEMA)
 	g.mzEMA += a * (g.sim.Mz - g.mzEMA)

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 	mode := flag.String("mode", "", "field display at startup: speed, vorticity, or pressure (default speed)")
 	udpAddr := flag.String("udp", "", "listen address (e.g. :9000) for UDP slider control from external hardware; disabled if empty")
 	debug := flag.Bool("debug", false, "log per-second performance lines and events to the terminal")
+	tps := flag.Int("tps", 60, "simulation ticks per second; lower values (e.g. 30) free a slow machine to draw more frames, with the flow speed unchanged")
 	scenePath := flag.String("scene", "", "path to an .afoil scene file to load at startup instead of the interactive default foil")
 	fullscreen := flag.Bool("fullscreen", false, "start in full screen")
 	hideControls := flag.Bool("hidecontrols", false, "hide every panel and control, showing only the flow image (kiosk mode)")
@@ -34,6 +35,14 @@ func main() {
 
 	g := NewGame()
 	g.perf.enabled = *debug
+	if *tps != 60 {
+		if validTPS(*tps) {
+			g.tps = *tps
+			ebiten.SetTPS(*tps)
+		} else {
+			log.Printf("kutta: -tps %d: not a clean divisor of the physics rate; keeping 60", *tps)
+		}
+	}
 	g.glow = *glow
 	g.streamlines = *streamlines
 	if *mode != "" {

--- a/tickrate.go
+++ b/tickrate.go
@@ -1,0 +1,51 @@
+package main
+
+import "math"
+
+// Tick-rate rebudget for machines that cannot update and draw 60 times a
+// second. John's Pi 5 log made the waste visible: with the solver fast enough
+// to hold 60 ticks, the main thread spent 544 ms of every second computing 60
+// simulation updates of which only 17 reached the screen.
+//
+// Lowering the tick rate does not slow the flow: the physics rate is
+// substeps x tps solver steps per second, so -tps 30 doubles the substeps per
+// tick and the flow, the timeline and the smoke all advance exactly as at 60.
+// What changes is the budget: half the ticks frees the thread to draw twice
+// the frames. The one real cost is input latency, one tick, 33 ms at 30.
+
+// validTPS reports whether the physics rate divides cleanly into tps ticks, so
+// every derived quantity below stays exact.
+func validTPS(tps int) bool {
+	return tps >= 10 && tps <= 60 && (substeps*60)%tps == 0
+}
+
+// tickTPS is the configured tick rate, defaulting to the standard 60 so tests
+// and benchmarks that build a bare Game are unaffected.
+func (g *Game) tickTPS() int {
+	if g.tps <= 0 {
+		return 60
+	}
+	return g.tps
+}
+
+// tickScale is how much longer one tick lasts compared to the 60-a-second
+// baseline; every per-tick advance multiplies by it.
+func (g *Game) tickScale() float64 {
+	return 60 / float64(g.tickTPS())
+}
+
+// substepsPerTick keeps the solver at the same steps per second regardless of
+// the tick rate.
+func (g *Game) substepsPerTick() int {
+	return substeps * 60 / g.tickTPS()
+}
+
+// emaAlphaPerTick compensates the force-readout smoothing so its time constant
+// stays the same wall-clock length at any tick rate.
+func (g *Game) emaAlphaPerTick() float64 {
+	const perTick60 = 0.04
+	if g.tickTPS() == 60 {
+		return perTick60
+	}
+	return 1 - math.Pow(1-perTick60, g.tickScale())
+}

--- a/tickrate_test.go
+++ b/tickrate_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+// TestTickRateKeepsPhysicsRate pins the invariant behind -tps: whatever the
+// tick rate, one wall-clock second must advance the solver, the timeline and
+// the smoke by exactly the same amount as the 60-tick baseline.
+func TestTickRateKeepsPhysicsRate(t *testing.T) {
+	for _, tps := range []int{10, 12, 15, 20, 30, 36, 45, 60} {
+		if !validTPS(tps) {
+			t.Errorf("validTPS(%d) = false, want it accepted", tps)
+			continue
+		}
+		g := simGame()
+		g.tps = tps
+
+		stepsPerSec := g.substepsPerTick() * tps
+		if stepsPerSec != substeps*60 {
+			t.Errorf("tps=%d: %d solver steps/s, want %d", tps, stepsPerSec, substeps*60)
+		}
+		animPerSec := animDt * g.tickScale() * float64(tps)
+		if math.Abs(animPerSec-animDt*60) > 1e-12 {
+			t.Errorf("tps=%d: timeline advances %.6f/s, want %.6f", tps, animPerSec, animDt*60)
+		}
+		tracerPerSec := tracerSpeed * g.tickScale() * float64(tps)
+		if math.Abs(tracerPerSec-tracerSpeed*60) > 1e-9 {
+			t.Errorf("tps=%d: smoke advects %.3f/s, want %.3f", tps, tracerPerSec, tracerSpeed*60)
+		}
+	}
+}
+
+// TestTickRateRejectsUnevenRates pins the validation: a rate that does not
+// divide the physics rate would drift the flow speed, so it is refused.
+func TestTickRateRejectsUnevenRates(t *testing.T) {
+	for _, tps := range []int{0, 7, 25, 50, 61, 120} {
+		if validTPS(tps) {
+			t.Errorf("validTPS(%d) = true, want it refused", tps)
+		}
+	}
+}
+
+// TestTickRateDefaultsWithoutFlag pins the zero value: a bare Game behaves
+// exactly as the 60-tick baseline, so nothing else in the app or the tests has
+// to know the feature exists.
+func TestTickRateDefaultsWithoutFlag(t *testing.T) {
+	g := simGame()
+	if g.tickTPS() != 60 || g.substepsPerTick() != substeps || g.tickScale() != 1 {
+		t.Errorf("bare Game: tps=%d substeps=%d scale=%v, want 60/%d/1",
+			g.tickTPS(), g.substepsPerTick(), g.tickScale(), substeps)
+	}
+	if g.emaAlphaPerTick() != 0.04 {
+		t.Errorf("bare Game: ema alpha = %v, want the baseline 0.04", g.emaAlphaPerTick())
+	}
+}
+
+// TestTickRateEMAEquivalence pins the smoothing compensation: after one second
+// of a constant input, the smoothed readout must land at the same value at 30
+// ticks as at 60, within float noise.
+func TestTickRateEMAEquivalence(t *testing.T) {
+	settle := func(tps int) float64 {
+		g := simGame()
+		g.tps = tps
+		a := g.emaAlphaPerTick()
+		v := 0.0
+		for range tps {
+			v += a * (1 - v)
+		}
+		return v
+	}
+	v60 := settle(60)
+	v30 := settle(30)
+	if math.Abs(v60-v30) > 1e-9 {
+		t.Errorf("after 1s of constant input: ema(60)=%v ema(30)=%v, want equal", v60, v30)
+	}
+}


### PR DESCRIPTION
John's Pi 5 log exposed the waste: with the solver fast enough to hold 60 ticks, the main thread spent 544 ms of every second computing 60 simulation updates of which 17 reached the screen. The other 43 were pure heat.

-tps 30 halves the ticks and doubles the substeps per tick, so the physics rate, the timeline and the smoke advection are unchanged per wall-clock second (the force-readout smoothing is compensated too); tickrate_test pins all of it. What changes is the budget: the freed thread time goes to drawing. The one real cost is input latency, one tick.

Measured: on macOS -tps 30 holds fps=60 with the same total solver cost per second. On a Pi 4 the per-second solver cost is identical at both rates (1235 vs 1203 ms), so the flag spends nothing; the display-rate win is the starved machine's to collect.