### PR TITLE
Add a CTRL UDP channel for control-surface deflection

### DIFF
--- a/udpcontrol.go
+++ b/udpcontrol.go
@@ -27,12 +27,11 @@ const udpRebindInterval = 30 * time.Second
 // this kind of private/local use), chosen automatically by whether the host
 // parses as a multicast IP.
 //
-// Channels: AOA and SPD (angle of attack, inlet speed, both numeric), GLOW,
-// STREAMLINES, PARTICLES and LABEL (0 or 1), MODE (speed, vorticity, or
-// pressure), and DEMO (seconds of no real input before the sim gently wanders
-// on its own; 0 disables it), mirroring the -demo flag exactly. A
-// control-surface channel is a natural follow-up once there's a live
-// control-surface slider for it to drive.
+// Channels: AOA, SPD and CTRL (angle of attack, inlet speed, control-surface
+// deflection in degrees; all numeric), GLOW, STREAMLINES, PARTICLES and LABEL
+// (0 or 1), MODE (speed, vorticity, or pressure), and DEMO (seconds of no
+// real input before the sim gently wanders on its own; 0 disables it),
+// mirroring the -demo flag exactly.
 func (g *Game) startUDPControl(addr string) error {
 	conn, err := listenUDPControl(addr)
 	if err != nil {
@@ -155,6 +154,16 @@ func (g *Game) applyControlMessage(line string) {
 			return
 		}
 		g.enqueue(func() { g.setSpeed(v) })
+	case "CTRL":
+		v, perr := strconv.ParseFloat(value, 64)
+		if perr != nil {
+			log.Printf("kutta: UDP control: CTRL wants a number, got %q", value)
+			return
+		}
+		// setControl clamps to +-controlLimit itself and is a harmless no-op
+		// when the loaded scene has no object marked Control, so the sender
+		// doesn't need to know whether one exists.
+		g.enqueue(func() { g.setControl(v) })
 	case "GLOW":
 		on, perr := strconv.ParseFloat(value, 64)
 		if perr != nil {

--- a/udpcontrol_test.go
+++ b/udpcontrol_test.go
@@ -100,6 +100,19 @@ func TestApplyControlMessageTogglesAndMode(t *testing.T) {
 		t.Error("LABEL 0 should turn the legend off")
 	}
 
+	g.applyControlMessage("CTRL 15")
+	g.drainPending()
+	if g.controlDeg != 15 {
+		t.Errorf("CTRL 15: controlDeg = %v, want 15", g.controlDeg)
+	}
+
+	// setControl clamps to +-controlLimit; confirm CTRL inherits that.
+	g.applyControlMessage("CTRL 999")
+	g.drainPending()
+	if g.controlDeg != controlLimit {
+		t.Errorf("CTRL 999: controlDeg = %v, want clamped to %v", g.controlDeg, controlLimit)
+	}
+
 	g.applyControlMessage("MODE pressure")
 	g.drainPending()
 	if g.mode != modePressure {


### PR DESCRIPTION
Closes #29.

Adds `CTRL <degrees>` to the UDP protocol, alongside `AOA`/`SPD`. Routes straight through the existing `setControl`, so it inherits the same ±`controlLimit` clamp as the on-screen slider and is a safe no-op with no scene, or a scene with no object marked `Control`.

Tested: `go test ./...` passes; added `TestApplyControlMessageTogglesAndMode` cases covering a normal value and clamping an out-of-range one.