### PR TITLE
Smooth field rendering at the body edge

### DIFF
--- a/game.go
+++ b/game.go
@@ -1275,11 +1275,31 @@ func (g *Game) fieldColor(x, y int) color.RGBA {
 	case modeVorticity:
 		return viz.Vorticity(g.sim.Vorticity(x, y), vortScale)
 	case modePressure:
-		return viz.Pressure(g.cp(c), cpScale)
+		return viz.Pressure(g.cpSmoothed(x, y), cpScale)
 	default:
 		speed := math.Hypot(g.sim.Ux[c], g.sim.Uy[c])
 		return viz.Speed(speed / (g.u0 * 2))
 	}
+}
+
+// cpSmoothed is the pressure coefficient at (x,y) averaged with its non-solid
+// axial neighbors, for display only. Bounce-back boundaries leave density with
+// more cell-to-cell noise than velocity (which goes smoothly to zero at a
+// no-slip wall) or vorticity (already smoothed by its central difference), so
+// the raw per-cell value renders visibly blocky right at the body surface
+// where it matters most; this doesn't touch the solver's actual Rho.
+func (g *Game) cpSmoothed(x, y int) float64 {
+	sum := g.cp(y*gridW + x)
+	n := 1.0
+	for _, d := range [4][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}} {
+		nx, ny := x+d[0], y+d[1]
+		if nx < 0 || nx >= gridW || ny < 0 || ny >= gridH || g.sim.Solid(nx, ny) {
+			continue
+		}
+		sum += g.cp(ny*gridW + nx)
+		n++
+	}
+	return sum / n
 }
 
 // cp is the pressure coefficient at cell c, from the lattice equation of state

--- a/game.go
+++ b/game.go
@@ -1266,19 +1266,57 @@ func (g *Game) paintField() {
 	g.fieldImg.WritePixels(g.pixbuf)
 }
 
+// edgeFeather softens a fluid cell's color toward the body's where they sit at
+// the raster grid's resolution, not the smooth vector outline's. That raster
+// edge is a stairstep in every mode; the vector outline (drawOutline) is thin
+// enough to leave it peeking out, and how visible that is depends on how much
+// the mode's color scheme contrasts against colBody right at the wall --
+// sharpest for pressure, since its diverging scale doesn't fade to zero at a
+// no-slip boundary the way speed and vorticity naturally do.
+const edgeFeather = 0.35
+
 func (g *Game) fieldColor(x, y int) color.RGBA {
 	if g.sim.Solid(x, y) {
 		return colBody
 	}
 	c := y*gridW + x
+	var col color.RGBA
 	switch g.mode {
 	case modeVorticity:
-		return viz.Vorticity(g.sim.Vorticity(x, y), vortScale)
+		col = viz.Vorticity(g.sim.Vorticity(x, y), vortScale)
 	case modePressure:
-		return viz.Pressure(g.cpSmoothed(x, y), cpScale)
+		col = viz.Pressure(g.cpSmoothed(x, y), cpScale)
 	default:
 		speed := math.Hypot(g.sim.Ux[c], g.sim.Uy[c])
-		return viz.Speed(speed / (g.u0 * 2))
+		col = viz.Speed(speed / (g.u0 * 2))
+	}
+	if g.adjacentToSolid(x, y) {
+		col = mixColor(col, colBody, edgeFeather)
+	}
+	return col
+}
+
+// adjacentToSolid reports whether any of (x,y)'s four axial neighbors is body.
+func (g *Game) adjacentToSolid(x, y int) bool {
+	for _, d := range [4][2]int{{1, 0}, {-1, 0}, {0, 1}, {0, -1}} {
+		nx, ny := x+d[0], y+d[1]
+		if nx < 0 || nx >= gridW || ny < 0 || ny >= gridH {
+			continue
+		}
+		if g.sim.Solid(nx, ny) {
+			return true
+		}
+	}
+	return false
+}
+
+// mixColor blends a toward b by t in [0,1].
+func mixColor(a, b color.RGBA, t float64) color.RGBA {
+	return color.RGBA{
+		R: uint8(float64(a.R) + (float64(b.R)-float64(a.R))*t),
+		G: uint8(float64(a.G) + (float64(b.G)-float64(a.G))*t),
+		B: uint8(float64(a.B) + (float64(b.B)-float64(a.B))*t),
+		A: 0xff,
 	}
 }
 


### PR DESCRIPTION
Closes #31.

Two related display-only fixes, neither touching solver state:
- `cpSmoothed` averages a cell's pressure coefficient with its non-solid axial neighbors before coloring, fixing the blocky pressure-mode look.
- `edgeFeather` blends any solid-adjacent fluid cell's color toward the body color, softening the raster stairstep that the thin vector outline doesn't fully cover — most visible where a mode's color scheme contrasts sharply against the body, worst in pressure mode.

Tested: `go test ./...` passes.