### PR TITLE
Add -demo: idle-triggered auto-wander mode

### DIFF
--- a/demo_test.go
+++ b/demo_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDemoModeIdleAndCancel pins the -demo state machine: it must not
+// activate before demoIdleSec of no real input has elapsed, and any real
+// input (via the same setSpeed/setAlpha/setControl choke points sliders,
+// keyboard and UDP all go through) must cancel it immediately.
+func TestDemoModeIdleAndCancel(t *testing.T) {
+	g := simGame()
+	g.demoIdleSec = 60
+
+	g.lastUserInput = time.Now()
+	g.updateDemo()
+	if g.demoActive {
+		t.Error("demo should not activate before the idle interval elapses")
+	}
+
+	g.lastUserInput = time.Now().Add(-61 * time.Second)
+	g.updateDemo()
+	if !g.demoActive {
+		t.Error("demo should activate once idle for longer than demoIdleSec")
+	}
+
+	g.setAlpha(g.alphaDeg + 1)
+	if g.demoActive {
+		t.Error("real input (setAlpha) should cancel demo mode immediately")
+	}
+}
+
+// TestDemoModeDisabledByDefault pins demoIdleSec <= 0 as "feature off": no
+// amount of idle time should ever activate it.
+func TestDemoModeDisabledByDefault(t *testing.T) {
+	g := simGame()
+	g.demoIdleSec = 0
+	g.lastUserInput = time.Now().Add(-time.Hour)
+	g.updateDemo()
+	if g.demoActive {
+		t.Error("demoIdleSec <= 0 should never activate demo mode")
+	}
+}
+
+// TestDemoModeDriverDoesNotSelfCancel pins the applyingDemo guard: the demo
+// driver's own calls to the setters must not reset lastUserInput or cancel
+// demoActive, or the feature could never sustain a wander.
+func TestDemoModeDriverDoesNotSelfCancel(t *testing.T) {
+	g := simGame()
+	g.demoIdleSec = 60
+	g.demoActive = true
+	g.demoTargetSpeed = g.u0 + 0.01
+	g.demoTargetAoa = g.alphaDeg + 5
+	g.demoTargetCtrl = 10
+	g.demoNextRetime = time.Now().Add(time.Hour) // don't retarget mid-test
+
+	g.updateDemo()
+	if !g.demoActive {
+		t.Error("the demo driver's own updates must not cancel demoActive")
+	}
+}

--- a/game.go
+++ b/game.go
@@ -5,11 +5,13 @@ import (
 	"image"
 	"image/color"
 	"math"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/crgimenes/glaze/menu"
 	ui "github.com/crgimenes/minigui"
@@ -195,6 +197,22 @@ type Game struct {
 	kiosk         bool
 	kioskControls bool
 
+	// Demo mode: after demoIdleSec of no real change to speed/AoA/control (via
+	// setSpeed/setAlpha/setControl -- the same choke points sliders, keyboard
+	// and UDP already go through), the sim gently wanders those three on its
+	// own until any real input arrives again. demoIdleSec <= 0 disables the
+	// feature entirely. applyingDemo distinguishes the demo driver's own calls
+	// to those setters from real input, so it doesn't reset its own idle timer
+	// or immediately cancel itself.
+	demoIdleSec     float64
+	demoActive      bool
+	applyingDemo    bool
+	lastUserInput   time.Time
+	demoNextRetime  time.Time
+	demoTargetSpeed float64
+	demoTargetAoa   float64
+	demoTargetCtrl  float64
+
 	// startFullscreen defers the -fullscreen flag until a few frames have been
 	// drawn: entering fullscreen during startup blanks the screen on macOS (it
 	// stays black until a resize), while toggling after launch works. The
@@ -334,6 +352,7 @@ func NewGame() *Game {
 		showParticles: true,
 		nacaCode:      profiles[0],
 		nacaInput:     profiles[0],
+		lastUserInput: time.Now(),
 	}
 	g.sim = lbm.New(gridW, gridH, tau, g.u0)
 	g.smoke = viz.NewParticles(nParticles, gridW, gridH, 1)
@@ -512,10 +531,58 @@ func (g *Game) controlObject() *scene.Object {
 // re-applying immediately so it moves even while the timeline is paused.
 func (g *Game) setControl(deg float64) {
 	g.controlDeg = math.Max(-controlLimit, math.Min(controlLimit, deg))
+	g.noteUserInput()
 	if g.scn == nil {
 		return
 	}
 	g.sim.UpdateSolid(g.sceneMask(g.scn.LoopTime(g.animTime)))
+}
+
+// noteUserInput marks real user activity on speed/AoA/control -- called from
+// their shared setters, so it sees every caller (sliders, keyboard, UDP)
+// automatically. It's a no-op while the demo driver itself is the one calling
+// those setters, so demo mode doesn't reset its own idle clock or instantly
+// cancel itself; any real caller immediately drops out of demo mode.
+func (g *Game) noteUserInput() {
+	if g.applyingDemo {
+		return
+	}
+	g.lastUserInput = time.Now()
+	g.demoActive = false
+}
+
+// updateDemo drives the idle-triggered wander: once demoIdleSec elapses with
+// no real input, it picks a new random (but valid) target for speed/AoA/
+// control every few seconds and eases the live value a fraction of the way
+// there each tick, so the motion reads as a gentle drift rather than a jump.
+// Any real input (via noteUserInput, called from the same setters this uses)
+// cancels demoActive immediately, handing control back.
+func (g *Game) updateDemo() {
+	if g.demoIdleSec <= 0 {
+		return
+	}
+	if !g.demoActive {
+		idleFor := time.Since(g.lastUserInput)
+		if idleFor < time.Duration(g.demoIdleSec*float64(time.Second)) {
+			return
+		}
+		g.demoActive = true
+		g.demoNextRetime = time.Time{} // force an immediate retarget below
+	}
+
+	if time.Now().After(g.demoNextRetime) {
+		g.demoTargetSpeed = spdMin + rand.Float64()*(spdMax-spdMin)
+		g.demoTargetAoa = -20 + rand.Float64()*40
+		g.demoTargetCtrl = -controlLimit + rand.Float64()*(2*controlLimit)
+		g.demoNextRetime = time.Now().Add(time.Duration(5+rand.IntN(4)) * time.Second)
+	}
+
+	const drift = 0.01 // fraction of the remaining distance to target, per tick
+	g.applyingDemo = true
+	g.setSpeed(g.u0 + (g.demoTargetSpeed-g.u0)*drift)
+	g.setAlpha(g.alphaDeg + (g.demoTargetAoa-g.alphaDeg)*drift)
+	g.setControl(g.controlDeg + (g.demoTargetCtrl-g.controlDeg)*drift)
+	g.applyingDemo = false
 }
 
 // Update steps the simulation and handles input.
@@ -746,6 +813,7 @@ func (g *Game) Update() error {
 		return nil
 	}
 	g.handleInput()
+	g.updateDemo()
 	if g.paused {
 		return nil
 	}
@@ -1171,6 +1239,7 @@ func (g *Game) setAlpha(deg float64) {
 		a += 360
 	}
 	g.alphaDeg = a
+	g.noteUserInput()
 	if g.scn == nil {
 		g.applyBody(false)
 		return
@@ -1193,6 +1262,7 @@ func (g *Game) setSpeed(u float64) {
 	g.simErr = ""
 	g.u0 = math.Max(0.02, math.Min(0.15, u))
 	g.sim.SetInletSpeed(g.u0)
+	g.noteUserInput()
 }
 
 // Draw paints the clipped simulation viewport and the two information panels —

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	kioskControls := flag.Bool("kiosk-controls", false, "in kiosk mode, keep the AoA/speed/control sliders visible and usable")
 	glow := flag.Bool("glow", true, "additive bloom on the smoke")
 	particles := flag.Bool("particles", true, "draw the smoke tracers; turn off to show streamlines alone against a clean background")
+	demo := flag.Float64("demo", 0, "seconds of no real input before the sim gently wanders speed/AoA/control on its own; 0 disables demo mode")
 	streamlines := flag.Bool("streamlines", false, "overlay integrated streamlines")
 	mode := flag.String("mode", "", "field display at startup: speed, vorticity, or pressure (default speed)")
 	udpAddr := flag.String("udp", "", "listen address (e.g. :9000) for UDP slider control from external hardware; disabled if empty")
@@ -54,6 +55,7 @@ func main() {
 	}
 	g.glow = *glow
 	g.showParticles = *particles
+	g.demoIdleSec = *demo
 	g.streamlines = *streamlines
 	if *mode != "" {
 		fm, ok := parseFieldMode(*mode)

--- a/udpcontrol.go
+++ b/udpcontrol.go
@@ -23,9 +23,11 @@ import (
 // parses as a multicast IP.
 //
 // Channels: AOA and SPD (angle of attack, inlet speed, both numeric), GLOW,
-// STREAMLINES and PARTICLES (0 or 1), and MODE (speed, vorticity, or
-// pressure). A control-surface channel is a natural follow-up once there's a
-// live control-surface slider for it to drive.
+// STREAMLINES and PARTICLES (0 or 1), MODE (speed, vorticity, or pressure),
+// and DEMO (seconds of no real input before the sim gently wanders on its
+// own; 0 disables it), mirroring the -demo flag exactly. A control-surface
+// channel is a natural follow-up once there's a live control-surface slider
+// for it to drive.
 func (g *Game) startUDPControl(addr string) error {
 	conn, err := listenUDPControl(addr)
 	if err != nil {
@@ -135,6 +137,22 @@ func (g *Game) applyControlMessage(line string) {
 			return
 		}
 		g.enqueue(func() { g.mode = fm })
+	case "DEMO":
+		v, perr := strconv.ParseFloat(value, 64)
+		if perr != nil {
+			log.Printf("kutta: UDP control: DEMO wants a number of seconds (0 disables), got %q", value)
+			return
+		}
+		g.enqueue(func() {
+			g.demoIdleSec = v
+			if v <= 0 {
+				// Hand control back immediately rather than freezing mid-wander:
+				// updateDemo skips everything once demoIdleSec <= 0, so without
+				// this it wouldn't apply further changes but also wouldn't clear
+				// the flag it's using to track that state.
+				g.demoActive = false
+			}
+		})
 	default:
 		log.Printf("kutta: UDP control: unknown channel %q", channel)
 	}

--- a/udpcontrol_test.go
+++ b/udpcontrol_test.go
@@ -102,4 +102,19 @@ func TestApplyControlMessageTogglesAndMode(t *testing.T) {
 	if g.mode != modePressure {
 		t.Errorf("invalid MODE value should be ignored; mode = %v, want unchanged modePressure", g.mode)
 	}
+
+	g.applyControlMessage("DEMO 45")
+	g.drainPending()
+	if g.demoIdleSec != 45 {
+		t.Errorf("DEMO 45: demoIdleSec = %v, want 45", g.demoIdleSec)
+	}
+	g.demoActive = true // simulate an in-progress wander
+	g.applyControlMessage("DEMO 0")
+	g.drainPending()
+	if g.demoIdleSec != 0 {
+		t.Errorf("DEMO 0: demoIdleSec = %v, want 0", g.demoIdleSec)
+	}
+	if g.demoActive {
+		t.Error("DEMO 0 should hand control back immediately, not freeze mid-wander")
+	}
 }


### PR DESCRIPTION
Closes #37.

After `-demo <seconds>` of no real change to speed/AoA/control, eases all three toward a randomly-refreshed target every few seconds — a calm drift, not a jump. Meant to keep an unattended exhibit display visually alive between visitors.

Hooks the existing `setSpeed`/`setAlpha`/`setControl` choke points via `noteUserInput`, so it sees input from sliders, keyboard, and UDP uniformly with no separate wiring per source, and cancels itself immediately on any real input. An `applyingDemo` guard keeps the demo driver's own calls to those setters from resetting its own idle clock or self-cancelling.

`DEMO <seconds>` UDP channel mirrors the `-demo` flag exactly (0 disables), rather than being a separate on/off toggle.

Tested: `go test ./...` passes.