### PR TITLE
Add -substeps: trade solver accuracy for CPU headroom on slower hardware

### DIFF
--- a/main.go
+++ b/main.go
@@ -30,7 +30,13 @@ func main() {
 	scenePath := flag.String("scene", "", "path to an .afoil scene file to load at startup instead of the interactive default foil")
 	fullscreen := flag.Bool("fullscreen", false, "start in full screen")
 	hideControls := flag.Bool("hidecontrols", false, "hide every panel and control, showing only the flow image (kiosk mode)")
+	substepsFlag := flag.Int("substeps", substeps, "solver steps per displayed frame; lower this on slower hardware to trade physical accuracy for CPU headroom")
 	flag.Parse()
+
+	if *substepsFlag < 1 {
+		log.Fatalf("kutta: -substeps %d: must be at least 1", *substepsFlag)
+	}
+	substeps = *substepsFlag
 
 	ebiten.SetWindowSize(winW, winH)
 	ebiten.SetWindowTitle(windowTitle)

--- a/substeps_js.go
+++ b/substeps_js.go
@@ -12,4 +12,7 @@ package main
 // The trade is that the flow evolves slower in wall-clock time than on the
 // desktop. Smooth and slow reads better than fast and juddering, and the
 // physics per step is identical either way.
-const substeps = 1
+//
+// It's a var, not a const, so the same -substeps flag in main.go that
+// overrides the native default can override this one too.
+var substeps = 1

--- a/substeps_other.go
+++ b/substeps_other.go
@@ -5,4 +5,8 @@ package main
 // substeps is how many solver steps advance per displayed frame. A native build
 // runs a step in about 2.3 ms on this grid, so three of them fit inside a 60 Hz
 // frame with room left for the smoke, the field and the panels.
-const substeps = 3
+//
+// It's a var, not a const: the -substeps flag in main.go overrides it, to
+// trade physical accuracy/responsiveness for CPU headroom on slower hardware
+// (e.g. a Raspberry Pi) without a rebuild.
+var substeps = 3


### PR DESCRIPTION
Closes #39.

Converts both build-tagged \`substeps\` consts to vars and adds \`-substeps\` to override either one at runtime, no rebuild needed.

Validated on-device: dropping from 3 to 2 on a Pi 5 cut solver time from ~15ms to ~10-11ms per tick (measured with \`-debug\`) — the difference between visibly catching up to the tick rate and visibly falling behind it, at the cost of the accuracy that one fewer LBM step per displayed frame represents.

Tested: \`go test ./...\` passes, plus a native and WASM build (this touches both build-tagged files).