### PR TITLE
add -max-kn flag to calibrate the legend's wind speed display

### DIFF
--- a/game.go
+++ b/game.go
@@ -179,6 +179,7 @@ type Game struct {
 	nacaInput     string  // NACA code being typed in the toolbar field
 	alphaDeg      float64 // angle of attack in degrees
 	u0            float64
+	maxDisplayKn  float64 // legend's "Wind speed" reading at full slider speed (spdMax) -- see -max-kn
 	controlDeg    float64 // live deflection of the scene's Control object, in degrees
 	mode          fieldMode
 	paused        bool
@@ -359,6 +360,7 @@ func NewGame() *Game {
 	g := &Game{
 		alphaDeg:      4,
 		u0:            defaultU,
+		maxDisplayKn:  25,
 		glow:          true,
 		showParticles: true,
 		nacaCode:      profiles[0],
@@ -1986,9 +1988,12 @@ func (g *Game) drawLabel(dst *ebiten.Image) {
 	ty = barY + barH + 4 + lineH + sectionGap
 
 	// Lattice units carry no real physical scale (see lbm's package doc), so
-	// this maps the same fraction of the solver's stable speed range onto a
-	// plausible desktop-exhibit knots range instead of a fabricated SI value.
-	knots := 25 * g.u0 / spdMax
+	// this maps the same fraction of the solver's stable speed range onto
+	// -max-kn instead of a fabricated SI value: full knob/slider speed
+	// (spdMax) reads as maxDisplayKn, scaling down proportionally at lower
+	// speeds -- set -max-kn to whatever aircraft's real max speed the
+	// exhibit is demonstrating.
+	knots := g.maxDisplayKn * g.u0 / spdMax
 	drawString(dst, fmt.Sprintf("Wind speed: %.0f kn", knots), tx, ty, colValue)
 	ty += lineH
 	drawString(dst, fmt.Sprintf("Angle of attack: %+.0f°", g.alphaDeg), tx, ty, colValue)

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 	fullscreen := flag.Bool("fullscreen", false, "start in full screen")
 	hideControls := flag.Bool("hidecontrols", false, "hide every panel and control, showing only the flow image (kiosk mode)")
 	substepsFlag := flag.Int("substeps", substeps, "solver steps per displayed frame; lower this on slower hardware to trade physical accuracy for CPU headroom")
+	maxKn := flag.Float64("max-kn", 25, "wind speed, in knots, the legend's \"Wind speed\" line reads at full slider/knob speed -- calibrate this to whatever real aircraft the exhibit demonstrates")
 	flag.Parse()
 
 	if *substepsFlag < 1 {
@@ -65,6 +66,7 @@ func main() {
 	g.showLabel = *label
 	g.demoIdleSec = *demo
 	g.streamlines = *streamlines
+	g.maxDisplayKn = *maxKn
 	if *mode != "" {
 		fm, ok := parseFieldMode(*mode)
 		if !ok {


### PR DESCRIPTION
Fixes #45.

Replaces the hardcoded 25kn placeholder in the legend's "Wind speed" line with a \`-max-kn\` flag (default 25, unchanged behavior) so an exhibit can calibrate the display to whatever real aircraft's max speed it's demonstrating, from the launch command line.